### PR TITLE
Fix layout typos in Dashboard and Sidebar

### DIFF
--- a/react-admin/src/scenes/dashboard/index.jsx
+++ b/react-admin/src/scenes/dashboard/index.jsx
@@ -5,7 +5,7 @@ import Header from "../../components/Header";
 const Dashboard = () => {
     return (
         <Box m="20px">
-            <Box display="flex" justifyContent="space-betweem" alignItems="center">
+            <Box display="flex" justifyContent="space-between" alignItems="center">
                 <Header title="Dashboard"  subtitle="Welcome to your Dashboard!" />
             </Box>
         </Box>

--- a/react-admin/src/scenes/global/Sidebar.jsx
+++ b/react-admin/src/scenes/global/Sidebar.jsx
@@ -57,9 +57,9 @@ const Sidebar = () => {
                 backgroundColor: "transparent !important"
             },
             "& .pro-inner-item": {
-                padding: "5px 35px 5px 20pxx !important"
+                padding: "5px 35px 5px 20px !important"
             },
-            "& .pro-innter-item:hover": {
+            "& .pro-inner-item:hover": {
                 color: "#868dfb !important"
             },
             "& .pro-menu-item.active": {
@@ -236,13 +236,13 @@ const Sidebar = () => {
                             selected={selected}
                             setSelected={setSelected}
                         /> 
-                       <Item 
-                            title="Line Chart"
-                            to="/lie"
-                            icon={<TimelineOutlinedIcon />}
-                            selected={selected}
-                            setSelected={setSelected}
-                        /> 
+                        <Item
+                             title="Line Chart"
+                             to="/line"
+                             icon={<TimelineOutlinedIcon />}
+                             selected={selected}
+                             setSelected={setSelected}
+                         />
                        <Item 
                             title="Geography Chart"
                             to="/geography"


### PR DESCRIPTION
## Summary
- fix spelling of `space-between` in Dashboard
- correct Sidebar CSS selector typos and fix line chart link

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68528eae4d408333adbd3f5f3cf04f7d