### PR TITLE
Apply theme tokens to AP calculator

### DIFF
--- a/react-admin/src/scenes/apcalculator/APCalculator.jsx
+++ b/react-admin/src/scenes/apcalculator/APCalculator.jsx
@@ -1,6 +1,7 @@
 // src/scenes/apcalculator/APCalculator.jsx
 import React, { useState } from 'react';
-import { Box, Typography, TextField, MenuItem, Button, IconButton, Autocomplete, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions } from '@mui/material';
+import { Box, Typography, TextField, MenuItem, Button, IconButton, Autocomplete, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, useTheme } from '@mui/material';
+import { tokens } from '../../theme';
 import { Bar } from 'react-chartjs-2';
 import axios from 'axios';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -27,6 +28,9 @@ const APCalculator = () => {
 
   const [university, setUniversity] = useState('wits');
   const [results, setResults] = useState(null);
+
+  const theme = useTheme();
+  const colors = tokens(theme.palette.mode);
 
   const handleChange = (index, field, value) => {
     const updated = [...subjectList];
@@ -61,7 +65,7 @@ const APCalculator = () => {
       {
         label: 'APS Points by University',
         data: Object.values(results),
-        backgroundColor: Object.keys(results).map(() => '#3f51b5')
+        backgroundColor: Object.keys(results).map(() => colors.blueAccent[500])
       }
     ]
   } : {
@@ -70,14 +74,16 @@ const APCalculator = () => {
       {
         label: `APS Points (${university.toUpperCase()})`,
         data: results ? [results.apsScore] : [0],
-        backgroundColor: ['#3f51b5']
+        backgroundColor: [colors.blueAccent[500]]
       }
     ]
   };
 
   return (
-    <Box m={4}>
-      <Typography variant="h4" gutterBottom>South African APS Calculator</Typography>
+    <Box m={4} sx={{ color: colors.grey[100] }}>
+      <Typography variant="h4" gutterBottom color={colors.greenAccent[400]}>
+        South African APS Calculator
+      </Typography>
 
       <TextField
         select
@@ -120,42 +126,86 @@ const APCalculator = () => {
           </Box>
         ))}
 
-        <Button variant="outlined" onClick={handleAddSubject}>
+        <Button
+          variant="outlined"
+          onClick={handleAddSubject}
+          sx={{
+            borderColor: colors.greenAccent[400],
+            color: colors.greenAccent[400],
+            '&:hover': {
+              borderColor: colors.greenAccent[300],
+              backgroundColor: colors.greenAccent[800],
+              color: colors.grey[100]
+            }
+          }}
+        >
           Add Another Subject
         </Button>
 
-        <Button variant="text" color="secondary" onClick={() => setRequestDialogOpen(true)}>
+        <Button
+          variant="text"
+          onClick={() => setRequestDialogOpen(true)}
+          sx={{
+            color: colors.blueAccent[300],
+            '&:hover': { backgroundColor: 'transparent', color: colors.blueAccent[200] }
+          }}
+        >
           Request to Add a Subject
         </Button>
 
-        <Button variant="contained" color="primary" onClick={handleSubmit}>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          sx={{
+            backgroundColor: colors.greenAccent[600],
+            color: colors.grey[900],
+            '&:hover': {
+              backgroundColor: colors.greenAccent[500]
+            }
+          }}
+        >
           Calculate APS
         </Button>
       </Box>
 
       {results && (
         <Box mt={5}>
-          <Typography variant="h6">Results:</Typography>
+          <Typography variant="h6" color={colors.grey[100]}>Results:</Typography>
           <Bar data={chartData} />
           {university === 'all' ? (
             Object.entries(results).map(([uni, score]) => (
-              <Typography key={uni} mt={2}>{uni.toUpperCase()} APS Score: {score}</Typography>
+              <Typography key={uni} mt={2} color={colors.grey[100]}>
+                {uni.toUpperCase()} APS Score: {score}
+              </Typography>
             ))
           ) : (
-            <Typography mt={2}>{university.toUpperCase()} APS Score: {results.apsScore}</Typography>
+            <Typography mt={2} color={colors.grey[100]}>
+              {university.toUpperCase()} APS Score: {results.apsScore}
+            </Typography>
           )}
         </Box>
       )}
 
       <Dialog open={requestDialogOpen} onClose={() => setRequestDialogOpen(false)}>
-        <DialogTitle>Request New Subject</DialogTitle>
+        <DialogTitle sx={{ color: colors.grey[100] }}>Request New Subject</DialogTitle>
         <DialogContent>
-          <DialogContentText>
+          <DialogContentText sx={{ color: colors.grey[100] }}>
             If your subject is not listed, you may request it to be added by contacting the administrator or submitting feedback.
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setRequestDialogOpen(false)} color="primary">Close</Button>
+          <Button
+            onClick={() => setRequestDialogOpen(false)}
+            sx={{
+              backgroundColor: colors.blueAccent[500],
+              color: colors.grey[100],
+              '&:hover': {
+                backgroundColor: colors.blueAccent[400]
+              }
+            }}
+          >
+            Close
+          </Button>
         </DialogActions>
       </Dialog>
     </Box>


### PR DESCRIPTION
## Summary
- apply MUI theme tokens to AP Calculator page
- set chart colors and text styles from theme
- theme-aware button background and font colors

## Testing
- `npm test --prefix react-admin --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855aa6c38f08333904fab83120de6bc