### PR TITLE
Integrate notistack and style APS results card

### DIFF
--- a/react-admin/package-lock.json
+++ b/react-admin/package-lock.json
@@ -27,6 +27,7 @@
         "axios": "^1.10.0",
         "chart.js": "^4.5.0",
         "formik": "^2.2.9",
+        "notistack": "^3.0.2",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.2.0",
@@ -9701,6 +9702,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -13398,6 +13408,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/notistack": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-3.0.2.tgz",
+      "integrity": "sha512-0R+/arLYbK5Hh7mEfR2adt0tyXJcCC9KkA2hc56FeWik2QN6Bm/S4uW+BjzDARsJth5u06nTjelSw/VSnB1YEA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.0",
+        "goober": "^2.0.33"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/notistack"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/npm-run-path": {

--- a/react-admin/package.json
+++ b/react-admin/package.json
@@ -22,6 +22,7 @@
     "axios": "^1.10.0",
     "chart.js": "^4.5.0",
     "formik": "^2.2.9",
+    "notistack": "^3.0.2",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.2.0",

--- a/react-admin/src/App.js
+++ b/react-admin/src/App.js
@@ -1,6 +1,7 @@
 import { ColorModeContext, useMode } from "./theme";
 import { CssBaseline, ThemeProvider } from "@mui/material";
-import { Routes, Route } from "react-router-dom"
+import { Routes, Route } from "react-router-dom";
+import { SnackbarProvider } from 'notistack';
 import Topbar from "./scenes/global/Topbar";
 import Sidebar from "./scenes/global/Sidebar";
 import Dashboard from "./scenes/dashboard";
@@ -29,7 +30,8 @@ function App() {
           <Sidebar />
           <main className="content">
             <Topbar />
-            <Routes>
+            <SnackbarProvider maxSnack={3}>
+              <Routes>
               <Route path="/" element={<Dashboard />} />
               <Route path="/courses" element={<Courses />} />
               <Route path="/apcalculator" element={<APCalculator />} />
@@ -44,6 +46,7 @@ function App() {
               <Route path="/geography" element={<Geography />} />
               <Route path="/calender" element={<Calendar />} /> */}
             </Routes>
+            </SnackbarProvider>
           </main>
         </div>
       </ThemeProvider>

--- a/react-admin/src/components/aps/APSResultsCard.jsx
+++ b/react-admin/src/components/aps/APSResultsCard.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Card, CardContent, Typography, useTheme } from '@mui/material';
+import { tokens } from '../../theme';
+const APSResultsCard = ({ title, score }) => {
+  const theme = useTheme();
+  const colors = tokens(theme.palette.mode);
+
+  return (
+    <Card sx={{ mt: 2, backgroundColor: colors.primary[400], color: colors.grey[100] }}>
+      <CardContent>
+        <Typography variant="h6" sx={{ color: colors.greenAccent[400] }}>
+          {title}
+        </Typography>
+        <Typography variant="body1">APS Score: {score}</Typography>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default APSResultsCard;


### PR DESCRIPTION
## Summary
- wrap app routing with `SnackbarProvider`
- install `notistack` for toast messages
- add `APSResultsCard` component
- use theme colors for APS results card

## Testing
- `npm ci`
- `CI=true npm test --silent` *(fails: No tests found)*
- `curl -X POST http://localhost:5000/api/calculate -H "Content-Type: application/json" -d '{"university": "WITS", "subjects": [{"name": "Maths", "score": 85}]}'` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_6856efe37e74833397d6543d87cd72d7